### PR TITLE
Update build process in GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,15 +40,16 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.16.2
+      - name: Install build
+        run: python -m pip install build
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheels
+        run: python -m build --wheel
 
       - uses: actions/upload-artifact@v3
         with:
-          path: ./wheels/*.whl
+          path: ./dist/*.whl
+
 
   publish:
     name: Publish package


### PR DESCRIPTION
- Replace cibuildwheel with the build module for building wheels.
- This change reflects that the project is a pure-Python package and doesn't require the capabilities of cibuildwheel.
- Update the path for the upload-artifact action to match the output directory of the build module.