### PR TITLE
Fix bug in parameter omega

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+Version 1.5.8
+-------------
+Release date: 2024-09-24
+
+Fixed
+^^^^^
+- Changed the parameter :math:`\Omega` from ``7.15 * 1e-5`` to ``7.2722 * 1e-5``
+
+
+
 Version 1.5.6
 -------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pysolorie
-version = 1.5.7
+version = 1.5.8
 description = Orientation Analysis of Solar Panel
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/pysolorie/numerical_integration.py
+++ b/src/pysolorie/numerical_integration.py
@@ -37,7 +37,7 @@ class IrradiationCalculator:
 
     """
 
-    OMEGA = 7.15 * 1e-5
+    OMEGA = 7.2722 * 1e-5
 
     def __init__(
         self, climate_type: str, observer_altitude: int, observer_latitude: float
@@ -130,7 +130,7 @@ class IrradiationCalculator:
                 solar energy received per unit area per second
                 on day number :math:`n` of the year
 
-        | - :math:`\Omega` = ``7.15 * 1e-5``
+        | - :math:`\Omega` = ``7.2722 * 1e-5``
 
         | - :math:`\theta` is incidence angle, the angle between the position vector
                 of the sun and the normal vector to the solar panel.

--- a/tests/test_numerical_integration.py
+++ b/tests/test_numerical_integration.py
@@ -31,7 +31,7 @@ from pysolorie import IrradiationCalculator
             35.6892,
             172,
             45.0,
-            20.3026,  # Tehran Summer, day_of_year=172 (June 21)
+            19.961,  # Tehran Summer, day_of_year=172 (June 21)
         ),
         (
             "MIDLATITUDE WINTER",
@@ -39,7 +39,7 @@ from pysolorie import IrradiationCalculator
             35.6892,
             355,
             45.0,
-            19.436,  # Tehran Winter, day_of_year=355 (Dec 21)
+            19.110,  # Tehran Winter, day_of_year=355 (Dec 21)
         ),
         (
             "TROPICAL",
@@ -47,7 +47,7 @@ from pysolorie import IrradiationCalculator
             3.5952,
             100,
             45.0,
-            13.224,  # Medan, day_of_year=100 (April 10)
+            13.003,  # Medan, day_of_year=100 (April 10)
         ),
         (
             "SUBARCTIC SUMMER",
@@ -55,7 +55,7 @@ from pysolorie import IrradiationCalculator
             64.84361,
             200,
             45.0,
-            21.371,  # Fairbanks Summer, day_of_year=200 (July 19)
+            21.012,  # Fairbanks Summer, day_of_year=200 (July 19)
         ),
         (
             "SUBARCTIC SUMMER",


### PR DESCRIPTION
Fixed bug by changing the parameter omega from ``7.15 * 1e-5`` to ``7.2722 * 1e-5`` in numerical integration. I also updated test cases to reflect new parameter values. It is ready to publish new version 1.5.8
